### PR TITLE
Fix setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='dateminer',
         'unittest2',
     ],
     test_suite='unittest2.collector',
-    packages=find_packages(),
+    py_modules=['dateminer'],
     include_package_data=True,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Thanks for this module!

However, the current package does not work correctly for me when installed using pip:

```
$ pip install dateminer
(...)
Successfully installed dateminer-0.2
$ python -c "from dateminer import guess_date"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named dateminer
```

As the distribution only includes a top-level module and no packages, the setup script should use the `py_modules=[...]` keyword argument to `setup()` instead of `packages=[...]`.

https://docs.python.org/2/distutils/setupscript.html#listing-individual-modules

This PR implements this proposed fix.
